### PR TITLE
Add support for string paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openworklabs/filecoin-wallet-provider",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "a javascript package to send filecoin to addresses",
   "main": "./dist/index.js",
   "browser": "./lib/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import LotusRpcEngine from '@openworklabs/lotus-jsonrpc-engine'
 
 export { default as LocalNodeProvider } from './providers/LocalNodeProvider'
 export { default as LedgerProvider } from './providers/LedgerProvider'
+export * from './utils'
 
 class Filecoin {
   constructor(provider, { apiAddress, token } = {}) {

--- a/src/providers/LedgerProvider.js
+++ b/src/providers/LedgerProvider.js
@@ -1,5 +1,6 @@
 import FilecoinApp from '@zondax/ledger-filecoin'
 import { mapSeries } from 'bluebird'
+import convertPathFmt from '../utils/convertPathFmt'
 
 class LedgerProvider extends FilecoinApp {
   constructor(transport) {
@@ -64,14 +65,14 @@ class LedgerProvider extends FilecoinApp {
   getAccounts = async (nStart = 0, nEnd = 5, network = 't') => {
     this.throwIfBusy()
     this.ledgerBusy = true
-    const pathNetworkId = network === 'f' ? 461 : 1
+    const networkCode = network === 'f' ? 461 : 1
     const paths = []
     for (let i = nStart; i < nEnd; i += 1) {
-      paths.push([44, pathNetworkId, 5, 0, i])
+      paths.push(`m/44'/${networkCode}'/0/0/${i}`)
     }
     const addresses = await mapSeries(paths, async path => {
       const { addrString } = this.handleErrors(
-        await super.getAddressAndPubKey(path),
+        await super.getAddressAndPubKey(convertPathFmt(path)),
       )
       return addrString
     })
@@ -83,7 +84,7 @@ class LedgerProvider extends FilecoinApp {
     this.throwIfBusy()
     this.ledgerBusy = true
     const { signature_compact } = this.handleErrors(
-      await super.sign(path, signedMessage),
+      await super.sign(convertPathFmt(path), signedMessage),
     )
     return signature_compact.toString('base64')
   }
@@ -91,7 +92,9 @@ class LedgerProvider extends FilecoinApp {
   showAddressAndPubKey = async path => {
     this.throwIfBusy()
     this.ledgerBusy = true
-    const res = this.handleErrors(await super.showAddressAndPubKey(path))
+    const res = this.handleErrors(
+      await super.showAddressAndPubKey(convertPathFmt(path)),
+    )
     this.ledgerBusy = false
     return res
   }

--- a/src/utils/convertPathFmt.js
+++ b/src/utils/convertPathFmt.js
@@ -1,0 +1,8 @@
+// use temporarily to get path to be an array from a string format
+export default strPath =>
+  strPath
+    .slice(2)
+    .split('/')
+    .map(code =>
+      code[code.length - 1] === "'" ? Number(code.slice(0, -1)) : Number(code),
+    )

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,1 @@
+export { default as validatePath } from './validatePath'

--- a/src/utils/validatePath.js
+++ b/src/utils/validatePath.js
@@ -1,0 +1,25 @@
+/**
+ * Checks to see a valid path is on filecoin main or testnet and first 2 values are hardened
+ *
+ * valid: m/44'/461'/1'/0/0/0
+ * valid: m/44'/1'/1'/0/0/0
+ *
+ * invalid: m/44/461'/1/0/0/0
+ * invalid: m/44/461'/1'/
+ */
+
+export default path => {
+  const tree = path.split('/')
+  if (tree.length !== 6) return false
+  return tree.every((v, i) => {
+    if (i === 0 && v !== 'm') return false
+    if (i === 1 && v !== "44'") return false
+    if (i === 2 && v !== "461'" && v !== "1'") return false
+    if (i > 0 && i < 3) {
+      const isHardened = v[v.length - 1] === "'"
+      if (!isHardened) return false
+    }
+
+    return true
+  })
+}


### PR DESCRIPTION
This temporarily uses a converter for the ledger provider until ledger-filecoin-js adds support for strings

Bump version